### PR TITLE
Remove deprecated jCenter dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
This should allow for more consistent builds - jcenter is spotty and unreliable since support was dropped for it a couple years ago.